### PR TITLE
Generate wp-config.php file conditionally

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -49,13 +49,23 @@ services:
         - './wp-content:/app/wordpress/wp-content'
         # LINK WP-CONFIG.PHP FILE.
         - './wp-config.php:/app/wordpress/wp-config.php'
+    # Have a look at this for better idea of build states:
     # Not needed because we are creating having wordpress-core already downloaded.
     # build:
     #   - wp core download --version=5.8.3 --force --skip-content
     run:
       - sleep 2 # For some reason, we have to wait at least a second till database is up.
-      - | # Create salts
-        wp config shuffle-salts
+      - | # Create WordPress config file and add necessary constants and custom config. Currently this will not work because the volume mapping occurs before the file is created.🐛🐛
+        if test -f "$LANDO_WEBROOT/wp-config.php"; then
+          echo "Config file already exists."
+        else
+        wp config create --dbhost=database --dbname=wordpress --dbuser=wordpress --dbpass=wordpress --dbprefix=wp_ --force --extra-php <<PHP
+        \$redis_server = array(
+          'host'     => 'rediscache',
+          'port'     => 6379,
+        );
+        PHP
+        fi
       - wp config set WP_DEBUG true --raw
       - wp config set WP_DEBUG_LOG true --raw
       - wp config set WP_DEBUG_DISPLAY true --raw

--- a/setup.sh
+++ b/setup.sh
@@ -59,8 +59,7 @@ fi
 
 cp ~/wordpress/wordpress.setup-DO-NOT-DELETE/.lando.yml "$project_folder/.lando.yml"
 cp -r ~/wordpress/wordpress.setup-DO-NOT-DELETE/.lando "$project_folder/.lando"
-cp ~/wordpress/wordpress.setup-DO-NOT-DELETE/wp-config.php "$project_folder/wp-config.php"
-
+# cp ~/wordpress/wordpress.setup-DO-NOT-DELETE/wp-config.php "$project_folder/wp-config.php"
 
 # Clone the repo with the name `wp-content`.
 
@@ -81,6 +80,19 @@ fi
 # -n -> Don't print the final output in stdout
 
 sed '1 s/SD_WP_LANDO_APP_NAME/'$1'/' -i $project_folder'/.lando.yml'
+
+# Create the salts.
+
+cd ~/wordpress/wordpress.setup-DO-NOT-DELETE/wordpress-core
+
+wp config create --config-file=$project_folder/wp-config.php --dbhost=database --dbname=wordpress --dbuser=wordpress --dbpass=wordpress --dbprefix=wp_ --skip-check --extra-php <<PHP
+\$redis_server = array(
+	'host'     => 'rediscache',
+	'port'     => 6379,
+);
+PHP
+
+cd $project_folder
 
 # Run `lando start`
 


### PR DESCRIPTION
**Issue :**
#1

**Bug even after the fix🐛 :**

After project initialization at some point if you delete the `wp-config.php` file in your project and then run `lando stop` and then `lando start`, then ideally it should generate a new `wp-config.php` file. But currently this doesn't happen because the volume mapping occurs before the build scripts. And so, during volume mapping, there's the error.